### PR TITLE
Update README.md - fix two grammar mistakes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ We pre-train the models using [retromae](https://github.com/staoxiao/RetroMAE) a
 **You can fine-tune the embedding model on your data following our [examples](https://github.com/FlagOpen/FlagEmbedding/tree/master/examples/finetune).**
 We also provide a [pre-train example](https://github.com/FlagOpen/FlagEmbedding/tree/master/examples/pretrain).
 Note that the goal of pre-training is to reconstruct the text, and the pre-trained model cannot be used for similarity calculation directly, it needs to be fine-tuned.
-More training details for bge see [baai_general_embedding](https://github.com/FlagOpen/FlagEmbedding/blob/master/FlagEmbedding/baai_general_embedding/README.md).
+Fore more training details for bge see [baai_general_embedding](https://github.com/FlagOpen/FlagEmbedding/blob/master/FlagEmbedding/baai_general_embedding/README.md).
 
 
 
@@ -387,7 +387,7 @@ which is more accurate than embedding model (i.e., bi-encoder) but more time-con
 Therefore, it can be used to re-rank the top-k documents returned by embedding model.
 We train the cross-encoder on a multilingual pair data, 
 The data format is the same as embedding model, so you can fine-tune it easily following our [example](https://github.com/FlagOpen/FlagEmbedding/tree/master/examples/reranker). 
-More details please refer to [./FlagEmbedding/reranker/README.md](https://github.com/FlagOpen/FlagEmbedding/tree/master/FlagEmbedding/reranker)
+For more details please refer to [./FlagEmbedding/reranker/README.md](https://github.com/FlagOpen/FlagEmbedding/tree/master/FlagEmbedding/reranker)
 
 
 ## Contact


### PR DESCRIPTION
I have two encountered two grammar errors in REAME.md file inside section "**Train**"

" **fine-tuned. More training details..**" should be " **fine-tuned. For more training details..**"

"**More details please refer to..**"  should be "**For more details please refer to..**"

Screenshot

![Screenshot (98)](https://github.com/FlagOpen/FlagEmbedding/assets/115995339/ee890167-02d5-457b-a18d-be37d9def024)

