### PR TITLE
fix: add state_dict to avoid lacking of the method argument

### DIFF
--- a/FlagEmbedding/baai_general_embedding/retromae_pretrain/trainer.py
+++ b/FlagEmbedding/baai_general_embedding/retromae_pretrain/trainer.py
@@ -27,7 +27,7 @@ class PreTrainer(Trainer):
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 
-    def _save(self, output_dir: Optional[str] = None):
+    def _save(self, output_dir: Optional[str] = None, state_dict=None):
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Saving model checkpoint to {output_dir}")

--- a/FlagEmbedding/reranker/trainer.py
+++ b/FlagEmbedding/reranker/trainer.py
@@ -11,16 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 class CETrainer(Trainer):
-    def _save(self, output_dir: Optional[str] = None):
+    def _save(self, output_dir: Optional[str] = None, state_dict=None):
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)
         logger.info("Saving model checkpoint to %s", output_dir)
         # Save a trained model and configuration using `save_pretrained()`.
         # They can then be reloaded using `from_pretrained()`
         if not hasattr(self.model, 'save_pretrained'):
-            raise NotImplementedError(
-                f'MODEL {self.model.__class__.__name__} '
-                f'does not support save_pretrained interface')
+            raise NotImplementedError(f'MODEL {self.model.__class__.__name__} ' f'does not support save_pretrained interface')
         else:
             self.model.save_pretrained(output_dir)
         if self.tokenizer is not None and self.is_world_process_zero():
@@ -31,4 +29,3 @@ class CETrainer(Trainer):
 
     def compute_loss(self, model: CrossEncoder, inputs):
         return model(inputs)['loss']
-


### PR DESCRIPTION
During fine-tune embedding or reranker models under the latest transformers(may > 4.28.1), it will cause an exception due to the lacking of`state_dict` in current Trainer _save method when save the checkpoint.

Close: https://github.com/FlagOpen/FlagEmbedding/issues/233
