### PR TITLE
Fix to conda command

### DIFF
--- a/Long_LLM/activation_beacon/README.md
+++ b/Long_LLM/activation_beacon/README.md
@@ -26,7 +26,7 @@ pytorch==2.1.2 transformers==4.36.1 accelerate==0.25.0 datasets==2.14.7 numpy==1
 ```
 You can install our environment with:
 ```bash
-conda create -f environment.yaml --name activation-beacon
+conda env create -f environment.yaml --name activation-beacon
 ```
 
 ## Usage


### PR DESCRIPTION
Command shown in conda [Environment](https://github.com/FlagOpen/FlagEmbedding/tree/master/Long_LLM/activation_beacon#environment) setup, returns an error.

+ Fixed by adding `env` to the argument.

Reference:
- Anaconda : [Creating an environment from an environment.yml file](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file)