### PR TITLE
Update negative sampling in hn_mine to fix issue #464

### DIFF
--- a/FlagEmbedding/baai_general_embedding/finetune/hn_mine.py
+++ b/FlagEmbedding/baai_general_embedding/finetune/hn_mine.py
@@ -100,7 +100,10 @@ def find_knn_neg(model, input_file, candidate_pool, output_file, sample_range, n
     with open(output_file, 'w') as f:
         for data in train_data:
             if len(data['neg']) < negative_number:
-                data['neg'].extend(random.sample(corpus, negative_number - len(data['neg'])))
+                candidates = list(set(corpus) - set(data['pos'] + data['neg']))
+                if not candidates:
+                    candidates = list(set(corpus) - set(data['pos']))
+                data['neg'].extend(random.sample(candidates, negative_number - len(data['neg'])))
             f.write(json.dumps(data, ensure_ascii=False) + '\n')
 
 


### PR DESCRIPTION
关于解决 #464 的修改。
避免困难样本挖掘时，当召回负样本数量少于预设负采样数量，会随机采样到正样本、或重复采样负样本的问题。
修改为，默认从 `corpus` 中剔除正例和已召回的负例，再进行随机采样；若剔除后 `corpus` 为空，说明需要重复采样负样本才能满足负采样数量要求，则只剔除正样本、重复采样负样本即可。