### PR TITLE
Update flag_models.py to fix is_torch_npu_available as a function call

### DIFF
--- a/FlagEmbedding/flag_models.py
+++ b/FlagEmbedding/flag_models.py
@@ -26,7 +26,7 @@ class FlagModel:
             self.device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             self.device = torch.device("mps")
-        elif is_torch_npu_available:
+        elif is_torch_npu_available():
             self.device = torch.device("npu")
         else:
             self.device = torch.device("cpu")


### PR DESCRIPTION
On a Colab Notebook, I stumbled upon:

/usr/local/lib/python3.10/dist-packages/FlagEmbedding/flag_models.py in __init__(self, model_name_or_path, use_fp16)
    139             self.device = torch.device("mps")
    140         elif is_torch_npu_available:
--> 141             self.device = torch.device("npu")
    142         else:
    143             self.device = torch.device("cpu")

RuntimeError: Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, fpga, ort, xla, lazy, vulkan, mps, meta, hpu, mtia, privateuseone device type at start of device string: npu