### PR TITLE
Fix "idx" bug in split_data_by_length.py of BGE-M3

### DIFF
--- a/FlagEmbedding/BGE_M3/split_data_by_length.py
+++ b/FlagEmbedding/BGE_M3/split_data_by_length.py
@@ -130,7 +130,7 @@ class SplitByLengthHandler:
                 continue
 
             idxs = mapped_dataset.filter(lambda x: length_l <= x['max_length'] < length_r, num_proc=self.num_proc)
-            split_dataset = dataset.select(idxs['idx'])
+            split_dataset = dataset.select(list(idxs._indices.to_pandas()['indices'].values))
 
             split_info_dict[f'len-{length_l}-{length_r}'] = len(split_dataset)
 


### PR DESCRIPTION
In the split_data_by_length.py code inside BGE-M3, after filtering the dataset by "max_length" field, the "idx" field is somehow changed , so the `split_dataset = dataset.select(idxs["idx"])` will result in the wrong data. 
To deal with this issue, I suggest using the real list of "idx" given by `list(idxs._indices.to_pandas()['indices'].values) `.