### PR TITLE
Add package_data for Visualized_BGE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ setup(
     author_email='2906698981@qq.com',
     url='https://github.com/FlagOpen/FlagEmbedding',
     packages=find_packages(),
+    include_package_data=True,
+    package_data={
+        'FlagEmbedding': [
+            'visual/eva_clip/bpe_simple_vocab_16e6.txt.gz',
+            'visual/eva_clip/model_configs/*.json'
+        ],
+    },
     install_requires=[
         'torch>=1.6.0',
         'transformers>=4.33.0',


### PR DESCRIPTION
Currently, some files are missing, so installing the package with `pip install FlagEmbedding` does not enable the visual model to work.

We believe this issue arises because `bpe_simple_vocab_16e6.txt.gz` and `model_configs/*.json` for eva_clip are not included in the package when it is created.

Including these files in the package will resolve the error and allow it to run successfully.

Note that currently, if you use `pip install` and install the package from PyPI, you will likely encounter the following error.


```python
import torch
from FlagEmbedding.visual.modeling import Visualized_BGE

model = Visualized_BGE(model_name_bge="BAAI/bge-m3", model_weight=visualized_m3_path)

with torch.no_grad():
    query_emb = model.encode(
        text="Are there sidewalks on both sides of the Mid-Hudson Bridge?"
    )
```

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/hotchpotch/miniconda3/envs/py311/lib/python3.11/site-packages/FlagEmbedding/visual/eva_clip/bpe_simple_vocab_16e6.txt.gz'
```