### PR TITLE
Enable Visualized_BGE Inference on CPU

### DIFF
--- a/FlagEmbedding/visual/modeling.py
+++ b/FlagEmbedding/visual/modeling.py
@@ -96,6 +96,8 @@ class Visualized_BGE(nn.Module):
         if torch.cuda.is_available():
             self.device = torch.device('cuda')
             self.to(self.device)
+        else:
+            self.device = torch.device('cpu')
     
     def load_model(self, model_weight):
         self.load_state_dict(torch.load(model_weight, map_location='cpu'))


### PR DESCRIPTION
Currently, it seems to work only in a CUDA environment. This change ensures it will work correctly by specifying the use of the CPU when CUDA is not available.

```
AttributeError: 'Visualized_BGE' object has no attribute 'device'
```

This change ensures it will work correctly by specifying the use of the CPU when CUDA is not available.

