### PR TITLE
allow HF model download, allow disabling tqdm bars

### DIFF
--- a/FlagEmbedding/flag_reranker.py
+++ b/FlagEmbedding/flag_reranker.py
@@ -469,7 +469,6 @@ class LayerWiseFlagLLMReranker:
         self.model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
                                                           cache_dir=cache_dir,
                                                           trust_remote_code=True,
-                                                          local_files_only=True,
                                                           torch_dtype=torch.bfloat16 if use_bf16 else torch.float32)
         if peft_path:
             self.model = PeftModel.from_pretrained(self.model,peft_path)
@@ -661,7 +660,6 @@ class LightWeightFlagLLMReranker:
         self.model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
                                                           cache_dir=cache_dir,
                                                           trust_remote_code=True,
-                                                          local_files_only=True,
                                                           torch_dtype=torch.bfloat16 if use_bf16 else torch.float32)
         if peft_path:
             self.model = PeftModel.from_pretrained(self.model,peft_path)


### PR DESCRIPTION
The first commit fixes a problem where the layerwise reranker classes could not download models from HF because `local_files_only=True` was set.

closes #721 

The second commit adds as `progress` keyword argument to all reranker `compute_score` methods, which allows the caller to activate/disable the tqdm progress bar. Some of these methods previously disabled the progress bar if the number of samples was less than the arbitrary value of 128. Now all methods will deactivate it by default if there is only one batch, but the user can choose to set it on or off regardless by passing `progress=True` or `progress=False`.