### PR TITLE
fix error in visualized bge

### DIFF
--- a/Manifest.in
+++ b/Manifest.in
@@ -1,0 +1,8 @@
+# Include the entire directory and its contents
+recursive-include FlagEmbedding/FlagEmbedding/visual/eva_clip *
+
+# Include the specific file at the root level
+include bpe_simple_vocab_16e6.txt.gz
+
+# Include all JSON files inside the specified directory
+recursive-include FlagEmbedding/visual/eva_clip/model_configs *.json

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ setup(
     author_email='2906698981@qq.com',
     url='https://github.com/FlagOpen/FlagEmbedding',
     packages=find_packages(),
+    include_package_data=True,
+    package_data={
+        'FlagEmbedding': [
+            'visual/eva_clip/bpe_simple_vocab_16e6.txt.gz',
+            'visual/eva_clip/model_configs/*.json'
+        ],
+    },
     install_requires=[
         'torch>=1.6.0',
         'transformers>=4.33.0',


### PR DESCRIPTION
Currently some of the eva_clip files are not included in pypi wheel. This PR fixes this bug.

fixes https://github.com/FlagOpen/FlagEmbedding/issues/628 and https://github.com/FlagOpen/FlagEmbedding/pull/936