### PR TITLE
Add cosine_similarity to hn_mine

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,7 @@ python hn_mine.py \
 --input_file toy_finetune_data.jsonl \
 --output_file toy_finetune_data_minedHN.jsonl \
 --range_for_sampling 2-200 \
+--similarity_range 0.3-0.8 \
 --negative_number 15 \
 --use_gpu_for_searching 
 ```
@@ -29,6 +30,7 @@ python hn_mine.py \
 - **`output_file`**: path to save JSON data with mined hard negatives for finetuning
 - **`negative_number`**: the number of sampled negatives
 - **`range_for_sampling`**: where to sample negative. For example, `2-100` means sampling `negative_number` negatives from top2-top200 documents. **You can set larger value to reduce the difficulty of negatives (e.g., set it `60-300` to sample negatives from top60-300 passages)**
+- **`similarity_range`**: Specifies the similarity score range for sampling negatives. This defines the range of similarity between the query and the negative samples. For example, "0.3-0.8" will only sample negatives with similarity scores between 0.3 and 0.8, allowing control over the difficulty of the negatives based on their relevance to the query. (e.g., setting it to "0.1-0.9" to sample negatives with similarity scores from 0.1 to 0.9), you can reduce the difficulty by including more diverse and less relevant negatives, whereas narrowing the range (e.g., "0.6-0.8") increases difficulty by focusing on more relevant negatives.
 - **`candidate_pool`**: The pool to retrieval. The default value is None, and this script will retrieve from the combination of all `neg` in `input_file`. The format of this file is the same as [pretrain data](https://github.com/FlagOpen/FlagEmbedding/tree/master/examples/pretrain#2-data-format). If input a candidate_pool, this script will retrieve negatives from this file.
 - **`use_gpu_for_searching`**: whether to use faiss-gpu to retrieve negatives.
 


### PR DESCRIPTION
By specifying a range for similarity scores when mining hard negatives, this argument ensures that negative examples fall within a desired difficulty level. This fine-tuned control helps in avoiding extremes—negatives that are either too close or too far in meaning from the query.

This is also explained in the paper (https://arxiv.org/pdf/2405.05374 (Appendix Algorithm 1: Tunable Negative Mining)), and I also used this code to mine hard negatives, and as a result, I was able to create a Reranker model that performed better than the hard negatives mined with the existing code. I would like to contribute to others using this code to create good models.