### PR TITLE
fixed a bug in AbsReranker.py for mps device support

### DIFF
--- a/FlagEmbedding/abc/inference/AbsReranker.py
+++ b/FlagEmbedding/abc/inference/AbsReranker.py
@@ -96,7 +96,7 @@ class AbsReranker(ABC):
             elif is_torch_npu_available():
                 return [f"npu:{i}" for i in range(torch.npu.device_count())]
             elif torch.backends.mps.is_available():
-                return [f"mps:{i}" for i in range(torch.mps.device_count())]
+                return ["mps"]
             else:
                 return ["cpu"]
         elif isinstance(devices, str):


### PR DESCRIPTION
fixed bug in issue #1215 

As PyTorch do not have torch.mps.device_count() function, and M-chip only support 1 device, so just change it like cpu, which return ["mps"] is ok.

Have already built it on my macOS, it works well.