### PR TITLE
fix DecoderOnlyEmbedderICLSameDatasetTrainDataset category index error

### DIFF
--- a/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
+++ b/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
@@ -113,8 +113,8 @@ class DecoderOnlyEmbedderICLSameDatasetTrainDataset(AbsEmbedderSameDatasetTrainD
                         add_special_tokens=False,
                     )['input_ids']
                 )
-                for i in range(len(tmp_passages)):
-                    tmp_passages[i] += self.args.icl_suffix_str
+                for j in range(len(tmp_passages)):
+                    tmp_passages[j] += self.args.icl_suffix_str
             else:
                 if self.args.passage_instruction_for_retrieval is not None:
                     tmp_passages = [


### PR DESCRIPTION
When I was fine-tuning use the [code](https://github.com/FlagOpen/FlagEmbedding/tree/master/examples/finetune/embedder#4-bge-en-icl) in the documentation for ```bge-en-icl```, an error occurred.

error like:
```python
[rank2]:     batch_raw_data['category'][i],  # use category as example
[rank2]: IndexError: list index out of range
```

Looking at the source code, I found that it was due to the ```for``` loop i variable in DecoderOnlyEmbedderICLSameDatasetTrainDataset._create_batch_data being overridden by the new ```for``` loop i variable inside.

https://github.com/FlagOpen/FlagEmbedding/blob/9abcfc88291c16f52f7a7bb6b364e129593ea5e3/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py#L68-L69

https://github.com/FlagOpen/FlagEmbedding/blob/9abcfc88291c16f52f7a7bb6b364e129593ea5e3/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py#L116-L117


I modified the variable name of the inner for loop, ```i -> j```, fix this bug.
