### PR TITLE
Fix knowledge_distillation=False error

### DIFF
--- a/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
+++ b/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
@@ -125,7 +125,7 @@ class DecoderOnlyEmbedderICLSameDatasetTrainDataset(AbsEmbedderSameDatasetTrainD
 
             passages.extend(tmp_passages)
             
-            if len(teacher_scores) > 0 and len(passages) > 0:
+            if teacher_scores and len(teacher_scores) > 0 and len(passages) > 0:
                 assert len(teacher_scores) == len(passages)
 
             # add icl pairs

--- a/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
+++ b/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py
@@ -125,7 +125,7 @@ class DecoderOnlyEmbedderICLSameDatasetTrainDataset(AbsEmbedderSameDatasetTrainD
 
             passages.extend(tmp_passages)
             
-            if teacher_scores and len(teacher_scores) > 0 and len(passages) > 0:
+            if teacher_scores and passages:
                 assert len(teacher_scores) == len(passages)
 
             # add icl pairs


### PR DESCRIPTION
When I was fine-tuning ```bge-en-icl```, I got an error when use ```--knowledge_distillation False```

error like:
```shell
[rank0]:     if len(teacher_scores) > 0 and len(passages) > 0:
[rank0]: typeError: object of type 'NoneType' has no len()
```

I found that the reason is that when ``knowledge_distillation=False`` ``teacher_scores`` it becomes None.
https://github.com/FlagOpen/FlagEmbedding/blob/777a9ac317cc07968ed0a7ce60c7cbcd85c36d92/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py#L92-L100

https://github.com/FlagOpen/FlagEmbedding/blob/777a9ac317cc07968ed0a7ce60c7cbcd85c36d92/FlagEmbedding/finetune/embedder/decoder_only/icl/dataset.py#L128-L129