### PR TITLE
[fix] Update layerwise.py: avoid forced type conversion

### DIFF
--- a/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
@@ -111,8 +111,7 @@ class LayerWiseLLMReranker(AbsReranker):
         )
 
         if use_bf16 is False and use_fp16 is False:
-            warnings.warn("Due to model constraints, `use_bf16` and `use_fp16` cannot both be `False`. Here, `use_fp16` is set to `True` by default.", UserWarning)
-            self.use_fp16 = True
+            raise ValueError("Due to model constraints, Both use_bf16 and use_fp16 cannot be False. Please set at least one to True.")
         
         try:
             self.model = LayerWiseMiniCPMForCausalLM.from_pretrained(


### PR DESCRIPTION
During layerwise model initialization, if both use_bf16 and use_fp16 are set to false, use_fp16 is forcibly converted to true. However, in some scenarios, the warning’s granularity does not propagate to the Python terminal, causing users to overlook this implicit behavior and potentially introducing unexpected bugs.

Therefore, I have committed a version of the code that explicitly notifies the user of incorrect input parameters, making it more aligned with everyday usage.

---

在layerwise模型相关初始化时，当use_bf16和 use_fp16都为false时，use_fp16会被强制转换成true；然而在一些场景，warning的告警粒度传递不到python terminal中，让人关注不到这一隐性的情况，从而可能产生预期之外的bug。

因此commit一版代码，强制告知user传入参数有误，更符合日常使用。