### PR TITLE
[fix]Update merge model related codes : avoid UnboundLocalError

### DIFF
--- a/research/llm_reranker/merge/merge_base_model.py
+++ b/research/llm_reranker/merge/merge_base_model.py
@@ -9,6 +9,7 @@ def merge_llm(model_name_or_path, lora_name_or_path, save_path, cache_dir: str =
                                                  trust_remote_code=True)
     model = PeftModel.from_pretrained(model, lora_name_or_path)
     model = model.merge_and_unload()
+    model._hf_peft_config_loaded = False
     model.save_pretrained(save_path)
 
     try:

--- a/research/llm_reranker/merge/merge_layerwise_model_from_finetuned_model.py
+++ b/research/llm_reranker/merge/merge_layerwise_model_from_finetuned_model.py
@@ -9,6 +9,7 @@ def merge_layerwise_finetuned_llm(model_name_or_path, lora_name_or_path, save_pa
                                                  trust_remote_code=True)
     model = PeftModel.from_pretrained(model, lora_name_or_path)
     model = model.merge_and_unload()
+    model._hf_peft_config_loaded = False
     model.save_pretrained(save_path)
 
     try:

--- a/research/llm_reranker/merge/merge_layerwise_model_from_raw_model.py
+++ b/research/llm_reranker/merge/merge_layerwise_model_from_raw_model.py
@@ -43,6 +43,7 @@ def merge_layerwise_raw_llm(model_name_or_path, lora_name_or_path, save_path, ca
 
     model = PeftModel.from_pretrained(model, lora_name_or_path)
     model = model.merge_and_unload()
+    model._hf_peft_config_loaded = False
     model.save_pretrained(save_path)
 
     try:


### PR DESCRIPTION
In Transformers = 4.43.1 and PEFT=0.12.0, merging llm_reranker_model in the original code will trigger an error: `UnboundLocalError: local variable 'active_adapters' referenced before assignment. `
By setting `model._hf_peft_config_loaded` to `False`,  can prevent this issue from occurring.

---

在transformers  = 4.43.1， peft  = 0.12.0版本中，原代码merge llm_reranker_model时会报错：`UnboundLocalError: local variable 'active_adapters' referenced before assignment。`
需要将`model._hf_peft_config_loaded`设为`False`，可以避免这个问题出现。