### PR TITLE
support musa backend in FlagEmbedding

### DIFF
--- a/FlagEmbedding/abc/inference/AbsReranker.py
+++ b/FlagEmbedding/abc/inference/AbsReranker.py
@@ -12,6 +12,11 @@ import numpy as np
 from tqdm import tqdm, trange
 from transformers import is_torch_npu_available
 
+try:
+    import torch_musa
+except Exception:
+    pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -107,6 +112,8 @@ class AbsReranker(ABC):
                 return [f"cuda:{i}" for i in range(torch.cuda.device_count())]
             elif is_torch_npu_available():
                 return [f"npu:{i}" for i in range(torch.npu.device_count())]
+            elif torch.musa.is_available():
+                return [f"musa:{i}" for i in range(torch.musa.device_count())]
             elif torch.backends.mps.is_available():
                 return ["mps"]
             else:
@@ -114,12 +121,18 @@ class AbsReranker(ABC):
         elif isinstance(devices, str):
             return [devices]
         elif isinstance(devices, int):
-            return [f"cuda:{devices}"]
+            if torch.musa.is_available():
+                return [f"musa:{devices}"]
+            else:
+                return [f"cuda:{devices}"]
         elif isinstance(devices, list):
             if isinstance(devices[0], str):
                 return devices
             elif isinstance(devices[0], int):
-                return [f"cuda:{device}" for device in devices]
+                if torch.musa.is_available():
+                    return [f"musa:{device}" for device in devices]
+                else:
+                    return [f"cuda:{device}" for device in devices]
             else:
                 raise ValueError("devices should be a string or an integer or a list of strings or a list of integers.")
         else:


### PR DESCRIPTION
What does this PR do?
It supports utilization of Moore Threads GPU in FlagEmbedding. The input of devices can be 0, [0], ["musa:0"], "musa:0". For example, the case below, you can set devices as 0, [0], ["musa:0"], "musa:0".

```python
import os
from FlagEmbedding import FlagModel

model = FlagModel(
    'BAAI/bge-small-en-v1.5',
    query_instruction_for_retrieval="Represent this sentence for searching relevant passages: ",
    query_instruction_format="{}{}",
    devices="musa:3",
    pooling_method='cls',
    cache_dir=os.getenv('HF_HUB_CACHE', None),
)

queries = [
    "What is the capital of France?",
    "What is the population of China?",
] * 100
passages = [
    "Paris is the capital of France.",
    "The population of China is over 1.4 billion people."
] * 100

queries_embeddings = model.encode_queries(queries)
passages_embeddings = model.encode_corpus(passages)

cos_scores = queries_embeddings @ passages_embeddings.T
print(cos_scores[:2, :2])
```
After running the code, you can get corresponding results.