### PR TITLE
pass kwargs into AutoModel.from_pretrained

### DIFF
--- a/FlagEmbedding/inference/embedder/encoder_only/base.py
+++ b/FlagEmbedding/inference/embedder/encoder_only/base.py
@@ -74,12 +74,14 @@ class BaseEmbedder(AbsEmbedder):
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name_or_path,
             trust_remote_code=trust_remote_code,
-            cache_dir=cache_dir
+            cache_dir=cache_dir,
+            **kwargs
         )
         self.model = AutoModel.from_pretrained(
             model_name_or_path,
             trust_remote_code=trust_remote_code,
-            cache_dir=cache_dir
+            cache_dir=cache_dir,
+            **kwargs
         )
 
     def encode_queries(


### PR DESCRIPTION
比如local_files_only必须传进去，要不断网后没法使用。直接把所有kwargs传进去是没问题的，因为 transformers/models/auto/auto_factory.py from_pretrained 函数对参数进行了过滤。