### PR TITLE
docs: fix link to https://bge-model.com/ within NEWS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ BGE (BAAI General Embedding) focuses on retrieval-augmented LLMs, consisting of 
 
 ## News
 
-- 05/12/2024: :book: We built the [BGE documentation](www.bge-model.com) for centralized BGE information and materials!
+- 05/12/2024: :book: We built the [BGE documentation](https://www.bge-model.com) for centralized BGE information and materials!
 - 10/29/2024: :earth_asia: We created WeChat group for BGE. Scan the [QR code](./imgs/BGE_WeChat_Group.png) to join the group chat! To get the first hand message about our updates and new release, or having any questions or ideas, join us now!
 - <img src="./imgs/BGE_WeChat_Group.png" alt="bge_wechat_group" class="center" width="200">
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ BGE (BAAI General Embedding) focuses on retrieval-augmented LLMs, consisting of 
 
 ## News
 
-- 05/12/2024: :book: We built the [BGE documentation](https://www.bge-model.com) for centralized BGE information and materials!
+- 12/5/2024: :book: We built the [BGE documentation](https://www.bge-model.com) for centralized BGE information and materials!
 - 10/29/2024: :earth_asia: We created WeChat group for BGE. Scan the [QR code](./imgs/BGE_WeChat_Group.png) to join the group chat! To get the first hand message about our updates and new release, or having any questions or ideas, join us now!
 - <img src="./imgs/BGE_WeChat_Group.png" alt="bge_wechat_group" class="center" width="200">
 


### PR DESCRIPTION
actual link: https://github.com/FlagOpen/FlagEmbedding/blob/master/www.bge-model.com
