### PR TITLE
add missing trust_remote_code[=true] when loading "openbmb/MiniCPM-Reranker-Light"

### DIFF
--- a/FlagEmbedding/inference/reranker/encoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/encoder_only/base.py
@@ -65,6 +65,7 @@ class BaseReranker(AbsReranker):
         )
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name_or_path, 
+            trust_remote_code=trust_remote_code, 
             cache_dir=cache_dir
         )
         self.model = AutoModelForSequenceClassification.from_pretrained(


### PR DESCRIPTION
add missing trust_remote_code[=true] when loading "openbmb/MiniCPM-Reranker-Light" to avoid prompt "The repository for xxx contains custom code which must be executed to correctly load the model. ..."