### PR TITLE
Add inline comment to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# setup.py: Configuration file for packaging FlagEmbedding using setuptools. 😊
 from setuptools import setup, find_packages
 
 with open("README.md", mode="r", encoding="utf-8") as readme_file:


### PR DESCRIPTION
Added an inline comment to setup.py to improve code clarity.

Added an inline comment to `setup.py` explaining its purpose, enhancing code clarity.