### PR TITLE
Make fine-tuning code runs properly in non-distributed mode.

### DIFF
--- a/FlagEmbedding/abc/finetune/embedder/AbsDataset.py
+++ b/FlagEmbedding/abc/finetune/embedder/AbsDataset.py
@@ -8,7 +8,7 @@ import torch.distributed as dist
 from dataclasses import dataclass
 from torch.utils.data import Dataset
 from transformers import (
-    PreTrainedTokenizer, 
+    PreTrainedTokenizer,
     DataCollatorWithPadding,
     TrainerCallback,
     TrainerState,
@@ -63,7 +63,8 @@ class AbsEmbedderTrainDataset(Dataset):
         Returns:
             datasets.Dataset: Loaded HF dataset.
         """
-        if dist.get_rank() == 0:
+        get_rank_safe = lambda: dist.get_rank() if dist.is_initialized() else 0
+        if get_rank_safe() == 0:
             logger.info(f'loading data from {file_path} ...')
 
         temp_dataset = datasets.load_dataset('json', data_files=file_path, split='train', cache_dir=self.args.cache_path)
@@ -342,7 +343,8 @@ class AbsEmbedderSameDatasetTrainDataset(AbsEmbedderTrainDataset):
         Returns:
             datasets.Dataset: The loaded dataset.
         """
-        if dist.get_rank() == 0:
+        get_rank_safe = lambda: dist.get_rank() if dist.is_initialized() else 0
+        if get_rank_safe() == 0:
             logger.info(f'loading data from {file_path} ...')
 
         temp_dataset = datasets.load_dataset('json', data_files=file_path, split='train', cache_dir=self.args.cache_path)


### PR DESCRIPTION
To avoid the error `ValueError: Default process group has not been initialized`, ensure the code can run correctly in non-distributed mode (e.g., during debugging or single-machine training).