### PR TITLE
fix abc/evaluation/runner.py: evaluate_metrics

### DIFF
--- a/FlagEmbedding/abc/evaluation/runner.py
+++ b/FlagEmbedding/abc/evaluation/runner.py
@@ -166,7 +166,8 @@ class AbsEvalRunner:
                 if os.path.exists(eval_results_path):
                     eval_results = json.load(open(eval_results_path, encoding='utf-8'))
                 else:
-                    raise FileNotFoundError(f"Eval results not found: {eval_results_path}")
+                    logger.warning(f"Eval results not found: {eval_results_path}")
+                    continue
 
                 if model_name not in eval_results_dict:
                     eval_results_dict[model_name] = {}


### PR DESCRIPTION
- when eval_results_path does not exist, continue