### PR TITLE
fix(deps): add peft version constraint to avoid 0.18 incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'datasets>=2.19.0',
         'accelerate>=0.20.1',
         'sentence_transformers',
-        'peft',
+        'peft>=0.11.0,<0.18.0',
         'ir-datasets',
         'sentencepiece',
         'protobuf'

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,21 @@
+"""Test dependency version constraints."""
+
+import ast
+import os
+
+
+def test_peft_version_constraint():
+    """Test that peft has proper version constraint in setup.py."""
+    setup_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "setup.py")
+
+    with open(setup_path, "r") as f:
+        content = f.read()
+
+    # Check that peft has version constraints
+    assert "peft>=" in content, "peft should have a minimum version constraint"
+    assert "peft" in content and "<0.18" in content, "peft should have an upper bound < 0.18"
+
+
+if __name__ == "__main__":
+    test_peft_version_constraint()
+    print("Dependency version constraint test passed!")


### PR DESCRIPTION
## Summary
- Added peft version constraint `>=0.11.0,<0.18.0` to avoid breaking changes in peft 0.18

## Problem
peft 0.18 introduces breaking changes that are incompatible with the current codebase.

## Test plan
- [x] Dependency constraint test passes

Fixes #1546