### PR TITLE
fix: Now model.half() called in __init__(), not in inference loop

### DIFF
--- a/FlagEmbedding/inference/reranker/decoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/base.py
@@ -250,6 +250,8 @@ class BaseLLMReranker(AbsReranker):
         if peft_path:
             self.model = PeftModel.from_pretrained(self.model, peft_path)
             self.model = self.model.merge_and_unload()
+        if self.use_fp16 and not all(d == "cpu" for d in self.target_devices):
+            self.model.half()
 
         self.yes_loc = self.tokenizer('Yes', add_special_tokens=False)['input_ids'][0]
 
@@ -296,16 +298,13 @@ class BaseLLMReranker(AbsReranker):
         if device is None:
             device = self.target_devices[0]
 
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
-
         self.model.to(device)
         self.model.eval()
 
         assert isinstance(sentence_pairs, list)
         if isinstance(sentence_pairs[0], str):
             sentence_pairs = [sentence_pairs]
-        
+
         # tokenize without padding to get the correct length
         all_queries_inputs = []
         all_passages_inputs = []

--- a/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
@@ -129,8 +129,10 @@ class LayerWiseLLMReranker(AbsReranker):
                 torch_dtype=torch.bfloat16 if use_bf16 else torch.float32
             )
         if peft_path:
-            self.model = PeftModel.from_pretrained(self.model,peft_path)
+            self.model = PeftModel.from_pretrained(self.model, peft_path)
             self.model = self.model.merge_and_unload()
+        if self.use_fp16 and not all(d == "cpu" for d in self.target_devices):
+            self.model.half()
 
     @torch.no_grad()
     def compute_score_single_gpu(
@@ -177,9 +179,6 @@ class LayerWiseLLMReranker(AbsReranker):
 
         if device is None:
             device = self.target_devices[0]
-
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/FlagEmbedding/inference/reranker/decoder_only/lightweight.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/lightweight.py
@@ -199,8 +199,10 @@ class LightweightLLMReranker(AbsReranker):
                 torch_dtype=torch.bfloat16 if use_bf16 else torch.float32
             )
         if peft_path:
-            self.model = PeftModel.from_pretrained(self.model,peft_path)
+            self.model = PeftModel.from_pretrained(self.model, peft_path)
             self.model = self.model.merge_and_unload()
+        if self.use_fp16 and not all(d == "cpu" for d in self.target_devices):
+            self.model.half()
 
     @torch.no_grad()
     def compute_score_single_gpu(
@@ -256,9 +258,6 @@ class LightweightLLMReranker(AbsReranker):
 
         if device is None:
             device = self.target_devices[0]
-
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/FlagEmbedding/inference/reranker/encoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/encoder_only/base.py
@@ -69,10 +69,12 @@ class BaseReranker(AbsReranker):
             cache_dir=cache_dir
         )
         self.model = AutoModelForSequenceClassification.from_pretrained(
-            model_name_or_path, 
-            trust_remote_code=trust_remote_code, 
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
             cache_dir=cache_dir
         )
+        if self.use_fp16 and not all(d == "cpu" for d in self.target_devices):
+            self.model.half()
 
     @torch.no_grad()
     def compute_score_single_gpu(
@@ -110,16 +112,13 @@ class BaseReranker(AbsReranker):
         if device is None:
             device = self.target_devices[0]
 
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
-
         self.model.to(device)
         self.model.eval()
 
         assert isinstance(sentence_pairs, list)
         if isinstance(sentence_pairs[0], str):
             sentence_pairs = [sentence_pairs]
-        
+
         # tokenize without padding to get the correct length
         all_inputs = []
         for start_index in trange(0, len(sentence_pairs), batch_size, desc="pre tokenize",

--- a/research/Matroyshka_reranker/inference/rank_model.py
+++ b/research/Matroyshka_reranker/inference/rank_model.py
@@ -146,7 +146,9 @@ class MatroyshkaReranker(AbsReranker):
             for p in peft_path:
                 self.model = PeftModel.from_pretrained(self.model, p)
                 self.model = self.model.merge_and_unload()
-    
+        if self.use_fp16 and not all(d == "cpu" for d in self.target_devices):
+            self.model.half()
+
     @torch.no_grad()
     def compute_score_single_gpu(
         self,
@@ -201,9 +203,6 @@ class MatroyshkaReranker(AbsReranker):
 
         if device is None:
             device = self.target_devices[0]
-
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
 
         self.model.to(device)
         self.model.eval()


### PR DESCRIPTION
## Fix: move `model.half()` to initialization in rerankers

### Problem

`self.model.half()` was called inside `compute_score_single_gpu()`, causing
repeated FP16 conversion on every inference call. This breaks on subsequent
calls, since `.half()` cannot be applied to an already FP16 model.

### Fix

Move FP16 conversion to `__init__()` after model (and optional PEFT adapter)
loading.
