### PR TITLE
fix: guard model.half() with dtype check in all rerankers

### DIFF
--- a/FlagEmbedding/inference/reranker/decoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/base.py
@@ -297,7 +297,8 @@ class BaseLLMReranker(AbsReranker):
             device = self.target_devices[0]
 
         if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
+        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+            self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/layerwise.py
@@ -179,7 +179,8 @@ class LayerWiseLLMReranker(AbsReranker):
             device = self.target_devices[0]
 
         if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
+        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+            self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/FlagEmbedding/inference/reranker/decoder_only/lightweight.py
+++ b/FlagEmbedding/inference/reranker/decoder_only/lightweight.py
@@ -258,7 +258,8 @@ class LightweightLLMReranker(AbsReranker):
             device = self.target_devices[0]
 
         if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
+        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+            self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/FlagEmbedding/inference/reranker/encoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/encoder_only/base.py
@@ -110,8 +110,8 @@ class BaseReranker(AbsReranker):
         if device is None:
             device = self.target_devices[0]
 
-        if device == "cpu": self.use_fp16 = False
-        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+        use_fp16 = self.use_fp16 and device != "cpu"
+        if use_fp16 and next(self.model.parameters()).dtype != torch.float16:
             self.model.half()
 
         self.model.to(device)

--- a/FlagEmbedding/inference/reranker/encoder_only/base.py
+++ b/FlagEmbedding/inference/reranker/encoder_only/base.py
@@ -111,7 +111,8 @@ class BaseReranker(AbsReranker):
             device = self.target_devices[0]
 
         if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
+        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+            self.model.half()
 
         self.model.to(device)
         self.model.eval()

--- a/research/Matroyshka_reranker/inference/rank_model.py
+++ b/research/Matroyshka_reranker/inference/rank_model.py
@@ -203,7 +203,8 @@ class MatroyshkaReranker(AbsReranker):
             device = self.target_devices[0]
 
         if device == "cpu": self.use_fp16 = False
-        if self.use_fp16: self.model.half()
+        if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
+            self.model.half()
 
         self.model.to(device)
         self.model.eval()


### PR DESCRIPTION
Calling .half() on an already-FP16 model raises an error, causing rerankers with use_fp16=True to crash on every request after the first. Add a dtype guard so the conversion only runs when needed:

if self.use_fp16 and next(self.model.parameters()).dtype != torch.float16:
    self.model.half()

Fixes BaseReranker, BaseLLMReranker, LightweightLLMReranker, LayerWiseLLMReranker, and MatroyshkaReranker.